### PR TITLE
Intruduced basic CMake configuration

### DIFF
--- a/BoostAssertConfig.cmake
+++ b/BoostAssertConfig.cmake
@@ -1,0 +1,7 @@
+# Copyright 2018 Thomas Jandecka
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+include(CMakeFindDependencyMacro)
+find_dependency(BoostConfig 1.66)
+include("${CMAKE_CURRENT_LIST_DIR}/BoostAssertTargets.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,54 @@
+# Copyright 2018 Thomas Jandecka
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+
+project(BoostAssert VERSION 1.66 LANGUAGES CXX)
+
+set(BoostAssert_PUBLIC_HEADERS
+    include/boost/assert.hpp
+    include/boost/current_function.hpp
+    )
+
+add_library(assert INTERFACE)
+
+target_include_directories(assert INTERFACE 
+    $<BUILD_INTERFACE:${BoostAssert_BINARY_DIR}/include>
+    $<BUILD_INTERFACE:${BoostAssert_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+    )
+
+find_package(BoostConfig 1.66 REQUIRED)
+
+target_link_libraries(assert
+    INTERFACE
+        Boost::config
+    )
+
+install(EXPORT assert-targets
+    FILE BoostAssertTargets.cmake
+    NAMESPACE Boost::
+    DESTINATION lib/cmake/boost
+    )
+
+install(TARGETS assert EXPORT assert-targets
+    INCLUDES DESTINATION include
+    PUBLIC_HEADER DESTINATION include/boost
+    )
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file("BoostAssertConfigVersion.cmake"
+    VERSION ${BoostAssert_VERSION}
+    COMPATIBILITY SameMajorVersion
+    )
+install(
+    FILES
+        "BoostAssertConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/BoostAssertConfigVersion.cmake"
+    DESTINATION
+        lib/cmake/boost
+    )
+install(FILES ${BoostAssert_PUBLIC_HEADERS} DESTINATION include/boost)
+
+add_library(Boost::assert ALIAS assert)


### PR DESCRIPTION
Expresses Boost::assert as an `INTERFACE` library in CMake.
- use via `add_subdirectory` 
- use via `find_package(BoostAssert 1.66)` if previously installed. This is achieved via the following install:
```
$INSTALL_PREFIX
├── include
│   └── boost
│       ├── assert.hpp
│       └── current_function.hpp
└── lib
    └── cmake
        └── boost
            ├── BoostAssertConfig.cmake
            ├── BoostAssertConfigVersion.cmake
            └── BoostAssertTargets.cmake

5 directories, 5 files
```
- tests are __not__ included in the build